### PR TITLE
Check server-wide permissions when doing actions on channel + Add flags value for badges

### DIFF
--- a/src/database/entities/server.rs
+++ b/src/database/entities/server.rs
@@ -108,6 +108,9 @@ pub struct Server {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub banner: Option<File>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flags: Option<i32>,
+
     #[serde(skip_serializing_if = "if_false", default)]
     pub nsfw: bool
 }

--- a/src/routes/channels/channel_edit.rs
+++ b/src/routes/channels/channel_edit.rs
@@ -36,13 +36,18 @@ pub async fn req(user: User, target: Ref, data: Json<Data>) -> Result<EmptyRespo
         return Ok(EmptyResponse {});
     }
 
+    let server = target.fetch_server().await?;
     let target = target.fetch_channel().await?;
-    let perm = permissions::PermissionCalculator::new(&user)
+    let serverPerm = permissions::PermissionCalculator::new(&user)
+        .with_server(&server)
+        .for_channel()
+        .await?;
+    let channelPerm = permissions::PermissionCalculator::new(&user)
         .with_channel(&target)
         .for_channel()
         .await?;
 
-    if !perm.get_manage_channel() {
+    if !serverPerm.get_manage_channel() && !channelPerm.get_manage_channel() {
         Err(Error::MissingPermission)?
     }
 


### PR DESCRIPTION
both server-wide and channel permissions are now checked when checking if user can modify/delete a channel