### PR TITLE
Mention regex is not global

### DIFF
--- a/src/routes/channels/message_send.rs
+++ b/src/routes/channels/message_send.rs
@@ -30,7 +30,7 @@ pub struct Data {
 }
 
 lazy_static! {
-    static ref RE_ULID: Regex = Regex::new(r"<@([0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26})>").unwrap();
+    static ref RE_ULID: Regex = Regex::new(r"<@([0-9A-Z]{26})>").unwrap();
 }
 
 #[post("/<target>/messages", data = "<message>")]
@@ -80,9 +80,10 @@ pub async fn message_send(_r: RateLimited<'_>, user: User, target: Ref, message:
     let id = Ulid::new().to_string();
 
     let mut mentions = HashSet::new();
-    if let Some(captures) = RE_ULID.captures_iter(&message.content).next() {
-        // ! FIXME: in the future, verify in group so we can send out push
-        mentions.insert(captures[1].to_string());
+    for capture in RE_ULID.captures_iter(&message.content) {
+        if let Some(mention) =  capture.get(1) {
+            mentions.insert(mention.as_str().to_string());
+        }
     }
 
     let mut replies = HashSet::new();


### PR DESCRIPTION
PR for https://github.com/revoltchat/delta/issues/43

The regex was only shortened, not changed, evaluating all captures found in captures_iter was sufficient.