### PR TITLE
Add basic server limit

### DIFF
--- a/src/database/entities/user.rs
+++ b/src/database/entities/user.rs
@@ -16,6 +16,7 @@ use crate::database::*;
 use crate::notifications::websocket::is_online;
 use crate::util::result::{Error, Result};
 use crate::util::variables::EARLY_ADOPTER_BADGE;
+use crate::util::variables::MAX_SERVER_COUNT;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum RelationshipStatus {
@@ -322,5 +323,11 @@ impl User {
             .filter_map(async move |s| s.ok())
             .collect::<Vec<Document>>()
             .await)
+    }
+
+    /// Check if this user can acquire another server.
+    pub async fn can_acquire_server(id: &str) -> Result<bool> {
+        let server_ids = User::fetch_server_ids(&id).await?;
+        Ok(server_ids.len() < *MAX_SERVER_COUNT)
     }
 }

--- a/src/routes/invites/invite_join.rs
+++ b/src/routes/invites/invite_join.rs
@@ -1,5 +1,6 @@
 use crate::database::*;
 use crate::util::result::{Error, Result};
+use crate::util::variables::MAX_SERVER_COUNT;
 
 use rocket::serde::json::Value;
 
@@ -7,6 +8,12 @@ use rocket::serde::json::Value;
 pub async fn req(user: User, target: Ref) -> Result<Value> {
     if user.bot.is_some() {
         return Err(Error::IsBot)
+    }
+
+    if !User::can_acquire_server(&user.id).await? {
+        Err(Error::TooManyServers {
+            max: *MAX_SERVER_COUNT,
+        })?
     }
     
     let target = target.fetch_invite().await?;

--- a/src/routes/servers/server_create.rs
+++ b/src/routes/servers/server_create.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::database::*;
 use crate::util::result::{Error, Result};
+use crate::util::variables::MAX_SERVER_COUNT;
 
 use mongodb::bson::doc;
 use rocket::serde::json::{Json, Value};
@@ -26,6 +27,12 @@ pub struct Data {
 pub async fn req(user: User, info: Json<Data>) -> Result<Value> {
     if user.bot.is_some() {
         return Err(Error::IsBot)
+    }
+
+    if !User::can_acquire_server(&user.id).await? {
+        Err(Error::TooManyServers {
+            max: *MAX_SERVER_COUNT,
+        })?
     }
     
     let info = info.into_inner();

--- a/src/util/result.rs
+++ b/src/util/result.rs
@@ -43,6 +43,9 @@ pub enum Error {
     UnknownServer,
     InvalidRole,
     Banned,
+    TooManyServers{
+        max: usize,
+    },
 
     // ? Bot related errors.
     ReachedMaximumBots,
@@ -111,6 +114,7 @@ impl<'r> Responder<'r, 'static> for Error {
             Error::UnknownServer => Status::NotFound,
             Error::InvalidRole => Status::NotFound,
             Error::Banned => Status::Forbidden,
+            Error::TooManyServers { .. } => Status::Forbidden,
 
             Error::ReachedMaximumBots => Status::BadRequest,
             Error::IsBot => Status::BadRequest,

--- a/src/util/variables.rs
+++ b/src/util/variables.rs
@@ -64,6 +64,8 @@ lazy_static! {
         env::var("REVOLT_MAX_GROUP_SIZE").unwrap_or_else(|_| "50".to_string()).parse().unwrap();
     pub static ref MAX_BOT_COUNT: usize =
         env::var("REVOLT_MAX_BOT_COUNT").unwrap_or_else(|_| "5".to_string()).parse().unwrap();
+    pub static ref MAX_SERVER_COUNT: usize =
+        env::var("REVOLT_MAX_SERVER_COUNT").unwrap_or_else(|_| "100".to_string()).parse().unwrap();
     pub static ref EARLY_ADOPTER_BADGE: i64 =
         env::var("REVOLT_EARLY_ADOPTER_BADGE").unwrap_or_else(|_| "0".to_string()).parse().unwrap();
 }


### PR DESCRIPTION
This came up in the testers server, and I wanted to brush up on my Rust - so I decided to give implementing this a try.

The default limit set in `variables.rs` is set to 100 by me, please let me know if this should be changed.

I moved the logic to check a user's eligibility to acquire another server into the user model, since in the future there may be ways for users to raise their limits.