### PR TITLE
Add youtube timestamp field to january models

### DIFF
--- a/src/database/entities/microservice/january.rs
+++ b/src/database/entities/microservice/january.rs
@@ -46,6 +46,9 @@ pub enum Special {
     None,
     YouTube {
         id: String,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        timestamp: Option<String>,
     },
     Twitch {
         content_type: TwitchType,


### PR DESCRIPTION
This is a companion PR for https://github.com/revoltchat/january/pull/11.