### PR TITLE
Implement ignored links, multiple link embeds

### DIFF
--- a/src/database/entities/microservice/january.rs
+++ b/src/database/entities/microservice/january.rs
@@ -100,10 +100,14 @@ impl Embed {
     pub async fn generate(content: String) -> Result<Vec<Embed>> {
         lazy_static! {
             static ref RE_CODE: Regex = Regex::new("```(?:.|\n)+?```|`(?:.|\n)+?`").unwrap();
+            static ref RE_IGNORED: Regex = Regex::new("(<http.+>)").unwrap();
         }
 
         // Ignore code blocks.
         let content = RE_CODE.replace_all(&content, "");
+
+        // Ignore all content between angle brackets starting with http.
+        let content = RE_IGNORED.replace_all(&content, "");
 
         let content = content
             // Ignore quoted lines.
@@ -121,7 +125,6 @@ impl Embed {
             .join("\n");
 
         // ! FIXME: allow multiple links
-        // ! FIXME: prevent generation if link is surrounded with < >
         let mut finder = LinkFinder::new();
         finder.kinds(&[LinkKind::Url]);
         let links: Vec<_> = finder.links(&content).collect();

--- a/src/util/variables.rs
+++ b/src/util/variables.rs
@@ -64,6 +64,8 @@ lazy_static! {
         env::var("REVOLT_MAX_GROUP_SIZE").unwrap_or_else(|_| "50".to_string()).parse().unwrap();
     pub static ref MAX_BOT_COUNT: usize =
         env::var("REVOLT_MAX_BOT_COUNT").unwrap_or_else(|_| "5".to_string()).parse().unwrap();
+    pub static ref MAX_EMBED_COUNT: usize =
+        env::var("REVOLT_MAX_EMBED_COUNT").unwrap_or_else(|_| "5".to_string()).parse().unwrap();
     pub static ref EARLY_ADOPTER_BADGE: i64 =
         env::var("REVOLT_EARLY_ADOPTER_BADGE").unwrap_or_else(|_| "0".to_string()).parse().unwrap();
 }


### PR DESCRIPTION
This PR adapts the link embed behaviour in the following ways:
* Links in angle brackets are now properly ignored, matching Discord's behaviour
* Multiple embeds are now fetched for one message, defaulting to 5(can be configured with `REVOLT_MAX_EMBED_COUNT`)
* Duplicate links do not get duplicate embeds

If the Rust in here is questionable, please let me know - still getting into it.