### PR TITLE
Allow users to change case of own username

### DIFF
--- a/src/routes/users/change_username.rs
+++ b/src/routes/users/change_username.rs
@@ -45,8 +45,7 @@ pub async fn req(
 
     let mut set = doc! {};
     if let Some(username) = &data.username {
-        if username.to_lowercase() == user.username.to_lowercase() {
-        } else if User::is_username_taken(&username).await? {
+        if (username.to_lowercase() != user.username.to_lowercase()) && User::is_username_taken(&username).await? {
             return Err(Error::UsernameTaken);
         }
 

--- a/src/routes/users/change_username.rs
+++ b/src/routes/users/change_username.rs
@@ -45,7 +45,8 @@ pub async fn req(
 
     let mut set = doc! {};
     if let Some(username) = &data.username {
-        if User::is_username_taken(&username).await? {
+        if username.to_lowercase() == user.username.to_lowercase() {
+        } else if User::is_username_taken(&username).await? {
             return Err(Error::UsernameTaken);
         }
 


### PR DESCRIPTION
Usernames are case-insensitive. One person cannot can have the name `foo` and someone else have the name `FOO`, but user `foo` should be able to change their own name to `FOO` if they want to for display purposes.

Fixes https://github.com/revoltchat/delta/issues/66