### PR TITLE
NSFW Patch for Channel

### DIFF
--- a/src/routes/channels/channel_edit.rs
+++ b/src/routes/channels/channel_edit.rs
@@ -32,6 +32,7 @@ pub async fn req(user: User, target: Ref, data: Json<Data>) -> Result<EmptyRespo
         && data.description.is_none()
         && data.icon.is_none()
         && data.remove.is_none()
+        && data.nsfw.is_none()
     {
         return Ok(EmptyResponse {});
     }


### PR DESCRIPTION
This is required to allow users to only enable NSFW without having to fill in any additional field like Name or Description.
Other Associated PRs:
[Revite#258](https://github.com/revoltchat/revite/pull/258)
[Revolt.js#15](https://github.com/revoltchat/revolt.js/pull/15)