### PR TITLE
Trust & Safety Staff Badge

### DIFF
--- a/src/database/entities/user.rs
+++ b/src/database/entities/user.rs
@@ -68,7 +68,7 @@ pub enum Badges {
     Translator = 2,
     Supporter = 4,
     ResponsibleDisclosure = 8,
-    RevoltTeam = 16,
+    TrustSafetyStaff = 16,
     EarlyAdopter = 256,
 }
 


### PR DESCRIPTION
As previously discussed, this introduces the Trust & Safety Badge. 
A seperate Team badge may not be a thing because there is already a dev badge. 
Respective PRs are opened in revite, delta, api and translations.